### PR TITLE
fix: corrected the namespace for the infrastructure-tools docker repository

### DIFF
--- a/.github/workflows/publish-tagged-image.yaml
+++ b/.github/workflows/publish-tagged-image.yaml
@@ -24,7 +24,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ secrets.DOCKER_USERNAME }}/infrastructure-tools
+          images: ailabsteam/infrastructure-tools
       
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc


### PR DESCRIPTION


I initially had the namespace set to the same as the username which would work for a personal account but not an organization